### PR TITLE
Fix compilation with gcc version 6.3.0 20170516 (Raspbian 6.3.0-18+rpi1+deb9u1)

### DIFF
--- a/gpio.c
+++ b/gpio.c
@@ -2,9 +2,9 @@
  * gpio.c:
  *	Access routines for the GPIO's on RPi.
  *	Parts of this code are borrowed from WiringPi and R42/pinokia - Luis Reis
- *	
  *
- *	
+ *
+ *
  **************************************************************
  * This file is part of rpiCC2500
  *
@@ -53,7 +53,7 @@
 // GPIO setup macros. Always use INP_GPIO(x) before using OUT_GPIO(x) or SET_GPIO_ALT(x,y)
 #define INP_GPIO(g) *(gpio + ((g) / 10)) &= ~(7 << (((g) % 10) * 3))
 #define OUT_GPIO(g) *(gpio + ((g) / 10)) |=  (1 << (((g) % 10) * 3))
-#define SET_GPIO_ALT(g,a) *(gpio + (((g) / 10))) |= (((a) <= 3 ? (a) + 4 : (a) == 4 ? 3 : 2) << (((g) % 10) * 3)) 
+#define SET_GPIO_ALT(g,a) *(gpio + (((g) / 10))) |= (((a) <= 3 ? (a) + 4 : (a) == 4 ? 3 : 2) << (((g) % 10) * 3))
 
 /*#define GPIOEDS_GET(g) (((*(gpio + 0x0040/4 + ((g) / 32))) & (1 << ((g) % 32) )) ? 1:0)
 //#define GPIOEDS_CLR(g) *(gpio + 0x0040/4 + ((g) / 32)) |= (1 << ((g) % 32) )
@@ -120,25 +120,25 @@ void gpio_shutdown() {
   close(mem_fd);
 }
 
-inline uint32_t gpio_word() {
+uint32_t gpio_word() {
   return gpio[13];
 }
 
-inline uint32_t gpio_set_input(uint32_t pin) {
+uint32_t gpio_set_input(uint32_t pin) {
   return INP_GPIO(pin);
 }
 
-inline uint32_t gpio_set_output(uint32_t pin) {
+uint32_t gpio_set_output(uint32_t pin) {
   INP_GPIO(pin);
   return OUT_GPIO(pin);
 }
 
-inline uint32_t gpio_alternate_function(uint32_t pin, uint32_t alternate) {
+uint32_t gpio_alternate_function(uint32_t pin, uint32_t alternate) {
   INP_GPIO(pin);
   return SET_GPIO_ALT(pin, alternate);
 }
 
-inline uint32_t gpio_set(uint32_t pins) {
+uint32_t gpio_set(uint32_t pins) {
   return GPIO_SET = pins;
 }
 
@@ -146,11 +146,11 @@ inline uint32_t gpio_clear(uint32_t pins) {
   return GPIO_CLR = pins;
 }
 
-inline int gpio_read(int port)
+int gpio_read(int port)
 {
 	return( (GPIO_GET & (1<<port)) ? 1 : 0);
 }
 
-inline uint32_t gpio_get(uint32_t pins) {
+uint32_t gpio_get(uint32_t pins) {
   return GPIO_GETBIT(pins);
 }

--- a/gpio.h
+++ b/gpio.h
@@ -2,9 +2,9 @@
  * gpio.h:
  *	Access routines for the GPIO's on RPi.
  *	Parts of this code are borrowed from WiringPi and R42/pinokia - Luis Reis
- *	
  *
- *	
+ *
+ *
  **************************************************************
  * This file is part of rpiCC2500
  *
@@ -40,13 +40,13 @@ void gpio_shutdown();
 
 #define inl(f) inline f __attribute__((always_inline))
 
-inl(uint32_t gpio_word());
-inl(uint32_t gpio_set_input(uint32_t pin));
-inl(uint32_t gpio_set_output(uint32_t pin));
-inl(uint32_t gpio_alternate_function(uint32_t pin, uint32_t alternate));
-inl(uint32_t gpio_set(uint32_t pins));
-inl(uint32_t gpio_clear(uint32_t pins));
-inl(int gpio_read(int port));
-inl(uint32_t gpio_get(uint32_t pins));
+uint32_t gpio_word();
+uint32_t gpio_set_input(uint32_t pin);
+uint32_t gpio_set_output(uint32_t pin);
+uint32_t gpio_alternate_function(uint32_t pin, uint32_t alternate);
+uint32_t gpio_set(uint32_t pins);
+uint32_t gpio_clear(uint32_t pins);
+int gpio_read(int port);
+uint32_t gpio_get(uint32_t pins);
 
 #endif


### PR DESCRIPTION
Remove inline functions in .c files

Apologies for the white space changes. I keep reverting them and they keep coming back. I suspect that it has something to do with the samba share on the Raspberry Pi that I'm using to edit the files.

I've not successfully made this work. Any information about how to connect the CC2500 to the Raspberry Pi would be gratefully received.

I'm trying to connect one of [these](https://www.aliexpress.com/item/Wireless-Module-CC2500-2-4G-Low-power-Consistency-Stability-Small-Size/32702148262.html) modules to one of [these](https://www.aliexpress.com/item/CC2500-PA-LNA-2-4G-SPI-22dBm-Wireless-Data-Transceiver-Module/32606419424.html) modules. I did have two of the latter modules but I seem to have blown one of them up by connecting it to the Raspberry Pi header upside down applying 5V to it 😬

![img_20190111_225152](https://user-images.githubusercontent.com/530659/51061496-c9e56100-15f3-11e9-9399-7309e67e6542.jpg)

